### PR TITLE
(fix) Avoid sometimes throwing the exceptions when the image list is …

### DIFF
--- a/src/components/CoolLightBox.vue
+++ b/src/components/CoolLightBox.vue
@@ -569,6 +569,11 @@ export default {
 
   watch: {
     zoomBar(newVal, prevVal) {
+
+      if (this.$refs.items.length === 0 || this.$refs.items[this.imgIndex].childNodes === 0 ) {
+        return false
+      }
+
       let item
       if(this.isZooming) {
         if(this.effect == 'swipe') {
@@ -1395,6 +1400,10 @@ export default {
         return false
       }
 
+      if (this.$refs.items.length === 0 || this.$refs.items[this.imgIndex].childNodes === 0 ) {
+        return false
+      }
+
       // item zoom
       let item
       if(this.effect == 'swipe') {
@@ -1452,6 +1461,10 @@ export default {
 
       // only if index is not null
       if(this.imgIndex != null) {
+        
+        if (this.$refs.items.length === 0 || this.$refs.items[this.imgIndex].childNodes === 0 ) {
+          return
+        }
 
         let item
         if(this.effect == 'swipe') {


### PR DESCRIPTION
I'm using nuxt content to render the page and sometimes it throws an exception that the childnodes are empty, which causes my whole page to go blank. 

I not sure how to trigger, maybe the page hasn't finished loading yet, but I mouse clicked around

I've added a way to avoid throwing this exception by determining in advance if the childnode is empty