### PR TITLE
Check .pdf extension in the url pathname.

### DIFF
--- a/src/components/CoolLightBox.vue
+++ b/src/components/CoolLightBox.vue
@@ -1687,7 +1687,8 @@ export default {
         return false
       }
 
-      const str = new String(url)
+      const urlObj = new URL(url)
+      const str = new String(urlObj.pathname)
       if(str.endsWith('.pdf')){
         return url
       }


### PR DESCRIPTION
This commit allows the module to detect the PDF extension even if the url contains query string (https://my-file.pdf?variable=value). Will be usefull with S3 signed URL.